### PR TITLE
Add PR review size rule

### DIFF
--- a/.cursor/rules/pr-review-size.mdc
+++ b/.cursor/rules/pr-review-size.mdc
@@ -1,0 +1,11 @@
+---
+description: Keep pull requests small and reviewable
+alwaysApply: true
+---
+
+# Pull Request Size
+
+- `lock file` を除き、各 `Pull Request` は変更行数がおおむね `300` 行前後に収まるようにする。
+- 初回の `Pull Request` でも同じサイズ目標を適用する。
+- このサイズを明確に超えそうな場合は、セットアップ、足場づくり、後続変更を別の `Pull Request` に分割する。
+- 作業分解では、レビューしやすい小さな `Pull Request` を優先する。

--- a/.cursor/rules/pr-review-size.mdc
+++ b/.cursor/rules/pr-review-size.mdc
@@ -5,7 +5,7 @@ alwaysApply: true
 
 # Pull Request Size
 
-- `lock file` を除き、各 `Pull Request` は変更行数がおおむね `300` 行前後に収まるようにする。
-- 初回の `Pull Request` でも同じサイズ目標を適用する。
-- このサイズを明確に超えそうな場合は、セットアップ、足場づくり、後続変更を別の `Pull Request` に分割する。
-- 作業分解では、レビューしやすい小さな `Pull Request` を優先する。
+- Excluding `lock file` changes, each `Pull Request` should usually stay around `300` changed lines.
+- Apply the same size target to the initial `Pull Request`.
+- If a change would clearly exceed that target, split setup, scaffolding, and follow-up work into separate `Pull Request`s.
+- When planning work, prefer small `Pull Request`s that are easy to review.


### PR DESCRIPTION
## Summary
- Add an always-applied `.cursor/rules/pr-review-size.mdc`
- Document the `300`-line review target excluding `lock file` changes
- Apply the same target to the initial `Pull Request` and recommend splitting larger setup work

## Test plan
- [x] Verified this is a rule-only change
- [x] Confirmed there are no runtime code changes


Made with [Cursor](https://cursor.com)