### PR TITLE
Ignore generated workspace files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+node_modules
+dist
+coverage
+.DS_Store
+.pnpm-store
+*.tsbuildinfo


### PR DESCRIPTION
## Summary
- add a root `.gitignore` for generated Node.js workspace artifacts
- keep local installs, build output, coverage output, and pnpm store files out of review diffs
- reduce noise when working on repository rules and docs updates

## Test plan
- [x] Confirm `git status` only reports `.gitignore` before commit
- [ ] No automated tests run; ignore-only change

Made with [Cursor](https://cursor.com)