### PR TITLE
Add git remote preflight rule

### DIFF
--- a/.cursor/rules/git-remote-preflight.mdc
+++ b/.cursor/rules/git-remote-preflight.mdc
@@ -1,0 +1,11 @@
+---
+description: Check remote and branch drift before editing
+alwaysApply: true
+---
+
+# Git Remote Preflight
+
+- Before starting substantive work, check the current branch, its upstream, and whether the base branch has moved on the remote.
+- Confirm whether local work differs from `origin/<current-branch>` and whether `main` is behind `origin/main` when that affects the task.
+- If the repository state is not what the user likely expects, pause and explain the mismatch before editing, committing, or opening a `Pull Request`.
+- Do not treat generated files alone as proof that source files changed; first confirm whether they come from branch drift, local installs, or build output.


### PR DESCRIPTION
## Summary
- add an always-on Cursor rule for checking branch and remote drift before substantive work starts
- prompt the agent to confirm upstream and base-branch mismatches before editing, committing, or opening a pull request
- reduce confusion from generated files that appear because of local installs or branch drift rather than source changes

## Test plan
- [x] Reviewed the new rule contents
- [ ] No automated tests run; rule-only change

Made with [Cursor](https://cursor.com)